### PR TITLE
.NET 8

### DIFF
--- a/src/SnapshotIt/Multithreading/ConcurrentCaptureIt.cs
+++ b/src/SnapshotIt/Multithreading/ConcurrentCaptureIt.cs
@@ -31,7 +31,6 @@ public static partial class CaptureIt<T>
                 ? Snapshot.Out.Copy<T>(value)
                 : value;
 
-            // locks the thread.
             spinLock.Enter(ref _locked);
 
             int _size = collection.Length;
@@ -74,7 +73,6 @@ public static partial class CaptureIt<T>
                 ? Snapshot.Out.Copy<T>(value)
                 : value;
 
-            // locks the thread.
             spinLock.Enter(ref _locked);
 
             int _size = collection.Length;


### PR DESCRIPTION
<h1>Locking threads</h1>
Performed new locker `SpinLock` from `System.Threading`. It is more appropriate to wait till obj will be unlocked instead of locking thread, more on that, it is struct, and definitely enhances performance.
